### PR TITLE
Implement label validation during the creation of new pull requests

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -1,0 +1,18 @@
+name: Check Pull Request
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+  merge_group:
+
+jobs:
+  validate-pr-label:
+    name: Validate the Pull Request's labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: PR must be labeled
+        uses: jesusvasquez333/verify-pr-label-action@v1.4.0
+        with:
+          disable-reviews: true
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          valid-labels: "backend, enhancement, bug, frontend, refactor"


### PR DESCRIPTION
- With this implementation, pull requests without labels will not be eligible for merging.

- Currently, we have 11 labels. We should decide which labels to retain and which to remove, then update the label list accordingly in the `check-pr.yml` file.