### PR TITLE
Remove unnecessary lines of code from Service Collection Extensions

### DIFF
--- a/Backend/src/BuildingBlocks/BuildingBlocks.Api/Converters/NodeIdConverter.cs
+++ b/Backend/src/BuildingBlocks/BuildingBlocks.Api/Converters/NodeIdConverter.cs
@@ -1,7 +1,0 @@
-namespace BuildingBlocks.Api.Converters;
-
-public class NodeIdConverter : IRegister
-{
-    public void Register(TypeAdapterConfig config) => 
-        config.NewConfig<NodeId, NodeId>().ConstructUsing(src => NodeId.Of(src.Value));
-}

--- a/Backend/src/BuildingBlocks/BuildingBlocks.Api/GlobalUsing.cs
+++ b/Backend/src/BuildingBlocks/BuildingBlocks.Api/GlobalUsing.cs
@@ -1,2 +1,0 @@
-global using Mapster;
-global using BuildingBlocks.Domain.ValueObjects.Ids;

--- a/Backend/src/Modules/Nodes/Nodes.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/Backend/src/Modules/Nodes/Nodes.Api/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,3 @@
-using BuildingBlocks.Api.Converters;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Nodes.Application.Extensions;
@@ -20,8 +19,6 @@ public static class ServiceCollectionExtensions
 
     private static IServiceCollection AddApiServices(this IServiceCollection services)
     {
-        TypeAdapterConfig.GlobalSettings.Scan(typeof(NodeIdConverter).Assembly);
-
         return services;
     }
 

--- a/Backend/src/Modules/Nodes/Nodes.Application/Extensions/ServiceCollectionExtensions.cs
+++ b/Backend/src/Modules/Nodes/Nodes.Application/Extensions/ServiceCollectionExtensions.cs
@@ -15,8 +15,6 @@ public static class ServiceCollectionExtensions
             config.AddOpenBehavior(typeof(LoggingBehavior<,>));
         });
 
-        services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());
-
         return services;
     }
 }

--- a/Backend/src/Modules/Nodes/Nodes.Domain/Events/NodeCreatedEvent.cs
+++ b/Backend/src/Modules/Nodes/Nodes.Domain/Events/NodeCreatedEvent.cs
@@ -2,4 +2,4 @@ using Nodes.Domain.Models;
 
 namespace Nodes.Domain.Events;
 
-public record NodeCreatedEvent(Node Node) : IDomainEvent { }
+public record NodeCreatedEvent(Node Node) : IDomainEvent;

--- a/Backend/src/Modules/Nodes/Nodes.Domain/Events/NodeUpdatedEvent.cs
+++ b/Backend/src/Modules/Nodes/Nodes.Domain/Events/NodeUpdatedEvent.cs
@@ -2,4 +2,4 @@ using Nodes.Domain.Models;
 
 namespace Nodes.Domain.Events;
 
-public record NodeUpdatedEvent(Node Node) : IDomainEvent { }
+public record NodeUpdatedEvent(Node Node) : IDomainEvent;


### PR DESCRIPTION
While working on #34 @NikolaDmitrasinovic noticed that validators and converters do not need to be registered through ServiceCollectionExtension calls, and therefore this PR removes such calls from the `Nodes` module as well.

This PR closes #38 .