### PR TITLE
Bring Back Validators to Nodes Module

### DIFF
--- a/Backend/src/Modules/Nodes/Nodes.Application/Entities/Nodes/Commands/CreateNode/CreateNodeCommand.cs
+++ b/Backend/src/Modules/Nodes/Nodes.Application/Entities/Nodes/Commands/CreateNode/CreateNodeCommand.cs
@@ -15,11 +15,37 @@ public class CreateNodeCommandValidator : AbstractValidator<CreateNodeCommand>
         RuleFor(x => x.Node.Title)
             .NotEmpty().WithMessage("Title is required.")
             .MaximumLength(100).WithMessage("Title must not exceed 100 characters.");
-        
+
         RuleFor(x => x.Node.Description)
             .NotEmpty().WithMessage("Description is required.")
             .MaximumLength(500).WithMessage("Description must not exceed 500 characters.");
 
-        // ToDo: Add remaining Node command validators
+        RuleFor(x => x.Node.Timestamp)
+            .LessThanOrEqualTo(DateTime.Now).WithMessage("Timestamp cannot be in the future.");
+
+        RuleFor(x => x.Node.Importance)
+            .InclusiveBetween(1, 10).WithMessage("Importance must be between 1 and 10.");
+
+        RuleFor(x => x.Node.Phase)
+            .NotEmpty().WithMessage("Phase is required.");
+        
+        RuleFor(x => x.Node)
+            .NotNull().WithMessage("Node cannot be null.")
+            .DependentRules(() =>
+            {
+                RuleFor(x => x.Node.Categories)
+                    .Must(categories => categories != null && categories.Count > 0)
+                    .WithMessage("At least one category must be provided.");
+                
+                RuleFor(x => x.Node.Tags)
+                    .Must(tags => tags != null && tags.Count > 0)
+                    .WithMessage("At least one tag must be provided.");
+            });
+
+        RuleForEach(x => x.Node.Categories)
+            .MaximumLength(50).WithMessage("Category must not exceed 50 characters.");
+
+        RuleForEach(x => x.Node.Tags)
+            .MaximumLength(50).WithMessage("Tag must not exceed 50 characters.");
     }
 }

--- a/Backend/src/Modules/Nodes/Nodes.Application/Extensions/ServiceCollectionExtensions.cs
+++ b/Backend/src/Modules/Nodes/Nodes.Application/Extensions/ServiceCollectionExtensions.cs
@@ -14,6 +14,8 @@ public static class ServiceCollectionExtensions
             config.AddOpenBehavior(typeof(ValidationBehavior<,>));
             config.AddOpenBehavior(typeof(LoggingBehavior<,>));
         });
+        
+        services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());
 
         return services;
     }


### PR DESCRIPTION
In this PR I have brought back validators to Nodes module's Api project's `ServiceCollectionExtension` class.