### PR TITLE
Validate Ids sent as part of GetNodeById requests

### DIFF
--- a/Backend/src/Modules/Nodes/Nodes.Application/Entities/Nodes/Queries/GetNodeById/GetNodeByIdHandler.cs
+++ b/Backend/src/Modules/Nodes/Nodes.Application/Entities/Nodes/Queries/GetNodeById/GetNodeByIdHandler.cs
@@ -7,12 +7,14 @@ internal class GetNodeByIdHandler(INodesDbContext dbContext) : IQueryHandler<Get
 {
     public async Task<GetNodeByIdResult> Handle(GetNodeByIdQuery query, CancellationToken cancellationToken)
     {
+        var nodeId = query.Id.ToString();
+        
         var node = await dbContext.Nodes
             .AsNoTracking()
-            .SingleOrDefaultAsync(n => n.Id == NodeId.Of(Guid.Parse(query.Id)), cancellationToken);
+            .SingleOrDefaultAsync(n => n.Id == NodeId.Of(Guid.Parse(nodeId)), cancellationToken);
 
         if (node is null)
-            throw new NodeNotFoundException(query.Id);
+            throw new NodeNotFoundException(nodeId);
         
         return new GetNodeByIdResult(node.ToNodeDto());
     }

--- a/Backend/src/Modules/Nodes/Nodes.Application/Entities/Nodes/Queries/GetNodeById/GetNodeByIdQuery.cs
+++ b/Backend/src/Modules/Nodes/Nodes.Application/Entities/Nodes/Queries/GetNodeById/GetNodeByIdQuery.cs
@@ -18,6 +18,6 @@ public class GetNodeByIdQueryValidator : AbstractValidator<GetNodeByIdQuery>
     {
         RuleFor(x => x.Id)
             .NotEmpty().WithMessage("Id is required.")
-            .Must(value => Guid.TryParse(value.ToString(), out _)).WithMessage("Invalid Id format.");
+            .Must(value => Guid.TryParse(value.ToString(), out _)).WithMessage("Id is not valid.");
     }
 }

--- a/Backend/src/Modules/Nodes/Nodes.Application/Entities/Nodes/Queries/GetNodeById/GetNodeByIdQuery.cs
+++ b/Backend/src/Modules/Nodes/Nodes.Application/Entities/Nodes/Queries/GetNodeById/GetNodeByIdQuery.cs
@@ -17,7 +17,7 @@ public class GetNodeByIdQueryValidator : AbstractValidator<GetNodeByIdQuery>
     public GetNodeByIdQueryValidator()
     {
         RuleFor(x => x.Id)
-            .NotEmpty().WithMessage("GUID is required.")
-            .Must(value => Guid.TryParse(value.ToString(), out _)).WithMessage("Invalid GUID format.");
+            .NotEmpty().WithMessage("Id is required.")
+            .Must(value => Guid.TryParse(value.ToString(), out _)).WithMessage("Invalid Id format.");
     }
 }

--- a/Backend/src/Modules/Nodes/Nodes.Application/Entities/Nodes/Queries/GetNodeById/GetNodeByIdQuery.cs
+++ b/Backend/src/Modules/Nodes/Nodes.Application/Entities/Nodes/Queries/GetNodeById/GetNodeByIdQuery.cs
@@ -4,7 +4,20 @@ using Nodes.Application.Entities.Nodes.Dtos;
 
 namespace Nodes.Application.Entities.Nodes.Queries.GetNodeById;
 
-public record GetNodeByIdQuery(string Id) : IQuery<GetNodeByIdResult>;
+public record GetNodeByIdQuery(NodeId Id) : IQuery<GetNodeByIdResult>
+{
+    public GetNodeByIdQuery(string Id) : this(NodeId.Of(Guid.Parse(Id))) { }
+}
 
 // ReSharper disable once NotAccessedPositionalProperty.Global
 public record GetNodeByIdResult(NodeDto NodeDto);
+
+public class GetNodeByIdQueryValidator : AbstractValidator<GetNodeByIdQuery>
+{
+    public GetNodeByIdQueryValidator()
+    {
+        RuleFor(x => x.Id)
+            .NotEmpty().WithMessage("GUID is required.")
+            .Must(value => Guid.TryParse(value.ToString(), out _)).WithMessage("Invalid GUID format.");
+    }
+}

--- a/Backend/src/Modules/Nodes/Nodes.Application/Entities/Nodes/Queries/ListNodes/ListNodesQuery.cs
+++ b/Backend/src/Modules/Nodes/Nodes.Application/Entities/Nodes/Queries/ListNodes/ListNodesQuery.cs
@@ -2,6 +2,7 @@ using BuildingBlocks.Application.Pagination;
 using Nodes.Application.Entities.Nodes.Dtos;
 
 // ReSharper disable ClassNeverInstantiated.Global
+// ReSharper disable NotAccessedPositionalProperty.Global
 
 namespace Nodes.Application.Entities.Nodes.Queries.ListNodes;
 


### PR DESCRIPTION
In this PR I've added validation of the Ids sent as part of GetNodeById requests. 

I would like to hear your opinion on whether we need this at all - what we get from this is: 
- A bit more specific error message when Ids as path variables are malformed or missing, as well as 
- An option to send a custom error code (right now it's 500, which is the worst option possible).

If you are against this, we can close the PR without merging it. If you agree with me that we need this, the change will have to be propagated to other modules, and other similar requests (the delete entity request is one such request).