### PR TITLE
BuildingBlocks: Move `Dtos`, `Events` and `ValueObjects` Under Newly Created `Reminder` Folder

### DIFF
--- a/Backend/src/BuildingBlocks/BuildingBlocks.Api/Converters/ReminderIdConverter.cs
+++ b/Backend/src/BuildingBlocks/BuildingBlocks.Api/Converters/ReminderIdConverter.cs
@@ -1,4 +1,4 @@
-﻿using BuildingBlocks.Domain.Reminders.ValueObjects;
+﻿using BuildingBlocks.Domain.Reminders.Reminder.ValueObjects;
 
 namespace BuildingBlocks.Api.Converters;
 

--- a/Backend/src/BuildingBlocks/BuildingBlocks.Application/Data/INodesService.cs
+++ b/Backend/src/BuildingBlocks/BuildingBlocks.Application/Data/INodesService.cs
@@ -1,6 +1,6 @@
 using BuildingBlocks.Domain.Nodes.Node.Dtos;
 using BuildingBlocks.Domain.Nodes.Node.ValueObjects;
-using BuildingBlocks.Domain.Reminders.ValueObjects;
+using BuildingBlocks.Domain.Reminders.Reminder.ValueObjects;
 
 namespace BuildingBlocks.Application.Data;
 

--- a/Backend/src/BuildingBlocks/BuildingBlocks.Application/Data/IRemindersService.cs
+++ b/Backend/src/BuildingBlocks/BuildingBlocks.Application/Data/IRemindersService.cs
@@ -1,5 +1,5 @@
-using BuildingBlocks.Domain.Reminders.Dtos;
-using BuildingBlocks.Domain.Reminders.ValueObjects;
+using BuildingBlocks.Domain.Reminders.Reminder.Dtos;
+using BuildingBlocks.Domain.Reminders.Reminder.ValueObjects;
 
 namespace BuildingBlocks.Application.Data;
 

--- a/Backend/src/BuildingBlocks/BuildingBlocks.Domain/Nodes/Node/Dtos/NodeDto.cs
+++ b/Backend/src/BuildingBlocks/BuildingBlocks.Domain/Nodes/Node/Dtos/NodeDto.cs
@@ -1,5 +1,5 @@
 using System.Text.Json.Serialization;
-using BuildingBlocks.Domain.Reminders.Dtos;
+using BuildingBlocks.Domain.Reminders.Reminder.Dtos;
 
 namespace BuildingBlocks.Domain.Nodes.Node.Dtos;
 

--- a/Backend/src/BuildingBlocks/BuildingBlocks.Domain/Reminders/Reminder/Dtos/ReminderBaseDto.cs
+++ b/Backend/src/BuildingBlocks/BuildingBlocks.Domain/Reminders/Reminder/Dtos/ReminderBaseDto.cs
@@ -1,17 +1,15 @@
 ﻿using System.Text.Json.Serialization;
-using BuildingBlocks.Domain.Nodes.Node.Dtos;
 
-namespace BuildingBlocks.Domain.Reminders.Dtos;
+namespace BuildingBlocks.Domain.Reminders.Reminder.Dtos;
 
-public class ReminderDto(
+public class ReminderBaseDto(
     string? id,
     string title,
     string description,
     DateTime dueDateTime,
     int priority,
     DateTime notificationTime,
-    string status,
-    NodeBaseDto node) // todo: Refactor this so that it extends ReminderBaseDto
+    string status)
 {
     [JsonPropertyName("id")] public string? Id { get; } = id;
 
@@ -26,6 +24,4 @@ public class ReminderDto(
     [JsonPropertyName("notificationTime")] public DateTime NotificationTime { get; } = notificationTime;
 
     [JsonPropertyName("status")] public string Status { get; } = status;
-    
-    [JsonPropertyName("node")] public NodeBaseDto Node { get; set; } = node;
 }

--- a/Backend/src/BuildingBlocks/BuildingBlocks.Domain/Reminders/Reminder/Dtos/ReminderDto.cs
+++ b/Backend/src/BuildingBlocks/BuildingBlocks.Domain/Reminders/Reminder/Dtos/ReminderDto.cs
@@ -1,15 +1,17 @@
 ﻿using System.Text.Json.Serialization;
+using BuildingBlocks.Domain.Nodes.Node.Dtos;
 
-namespace BuildingBlocks.Domain.Reminders.Dtos;
+namespace BuildingBlocks.Domain.Reminders.Reminder.Dtos;
 
-public class ReminderBaseDto(
+public class ReminderDto(
     string? id,
     string title,
     string description,
     DateTime dueDateTime,
     int priority,
     DateTime notificationTime,
-    string status)
+    string status,
+    NodeBaseDto node) // todo: Refactor this so that it extends ReminderBaseDto
 {
     [JsonPropertyName("id")] public string? Id { get; } = id;
 
@@ -24,4 +26,6 @@ public class ReminderBaseDto(
     [JsonPropertyName("notificationTime")] public DateTime NotificationTime { get; } = notificationTime;
 
     [JsonPropertyName("status")] public string Status { get; } = status;
+
+    [JsonPropertyName("node")] public NodeBaseDto Node { get; set; } = node;
 }

--- a/Backend/src/BuildingBlocks/BuildingBlocks.Domain/Reminders/Reminder/Events/ReminderCreatedEvent.cs
+++ b/Backend/src/BuildingBlocks/BuildingBlocks.Domain/Reminders/Reminder/Events/ReminderCreatedEvent.cs
@@ -1,0 +1,6 @@
+﻿using BuildingBlocks.Domain.Abstractions;
+using BuildingBlocks.Domain.Reminders.Reminder.ValueObjects;
+
+namespace BuildingBlocks.Domain.Reminders.Reminder.Events;
+
+public record ReminderCreatedEvent(ReminderId ReminderId) : IDomainEvent;

--- a/Backend/src/BuildingBlocks/BuildingBlocks.Domain/Reminders/Reminder/Events/ReminderUpdatedEvent.cs
+++ b/Backend/src/BuildingBlocks/BuildingBlocks.Domain/Reminders/Reminder/Events/ReminderUpdatedEvent.cs
@@ -1,0 +1,6 @@
+﻿using BuildingBlocks.Domain.Abstractions;
+using BuildingBlocks.Domain.Reminders.Reminder.ValueObjects;
+
+namespace BuildingBlocks.Domain.Reminders.Reminder.Events;
+
+public record ReminderUpdatedEvent(ReminderId ReminderId) : IDomainEvent;

--- a/Backend/src/BuildingBlocks/BuildingBlocks.Domain/Reminders/Reminder/ValueObjects/ReminderId.cs
+++ b/Backend/src/BuildingBlocks/BuildingBlocks.Domain/Reminders/Reminder/ValueObjects/ReminderId.cs
@@ -2,7 +2,7 @@
 using System.Text.Json.Serialization;
 using BuildingBlocks.Domain.Abstractions;
 
-namespace BuildingBlocks.Domain.Reminders.ValueObjects;
+namespace BuildingBlocks.Domain.Reminders.Reminder.ValueObjects;
 
 [JsonConverter(typeof(ReminderIdJsonConverter))]
 public class ReminderId : StronglyTypedId
@@ -22,27 +22,27 @@ public class ReminderIdJsonConverter : JsonConverter<ReminderId>
         switch (reader.TokenType)
         {
             case JsonTokenType.String:
-            {
-                var guidString = reader.GetString();
-                if (!Guid.TryParse(guidString, out var guid))
-                    throw new JsonException($"Invalid GUID format for ReminderId: {guidString}");
+                {
+                    var guidString = reader.GetString();
+                    if (!Guid.TryParse(guidString, out var guid))
+                        throw new JsonException($"Invalid GUID format for ReminderId: {guidString}");
 
-                return ReminderId.Of(guid);
-            }
+                    return ReminderId.Of(guid);
+                }
             case JsonTokenType.StartObject:
-            {
-                using var jsonDoc = JsonDocument.ParseValue(ref reader);
+                {
+                    using var jsonDoc = JsonDocument.ParseValue(ref reader);
 
-                if (!jsonDoc.RootElement.TryGetProperty("id", out JsonElement idElement))
-                    throw new JsonException("Expected property 'id' not found.");
+                    if (!jsonDoc.RootElement.TryGetProperty("id", out JsonElement idElement))
+                        throw new JsonException("Expected property 'id' not found.");
 
-                var guidString = idElement.GetString();
+                    var guidString = idElement.GetString();
 
-                if (!Guid.TryParse(guidString, out var guid))
-                    throw new JsonException($"Invalid GUID format for ReminderId: {guidString}");
+                    if (!Guid.TryParse(guidString, out var guid))
+                        throw new JsonException($"Invalid GUID format for ReminderId: {guidString}");
 
-                return ReminderId.Of(guid);
-            }
+                    return ReminderId.Of(guid);
+                }
             default:
                 throw new JsonException(
                     $"Unexpected token parsing ReminderId. Expected String or StartObject, got {reader.TokenType}.");

--- a/Backend/src/BuildingBlocks/BuildingBlocks.Domain/Reminders/Reminder/ValueObjects/ReminderId.cs
+++ b/Backend/src/BuildingBlocks/BuildingBlocks.Domain/Reminders/Reminder/ValueObjects/ReminderId.cs
@@ -22,27 +22,27 @@ public class ReminderIdJsonConverter : JsonConverter<ReminderId>
         switch (reader.TokenType)
         {
             case JsonTokenType.String:
-                {
-                    var guidString = reader.GetString();
-                    if (!Guid.TryParse(guidString, out var guid))
-                        throw new JsonException($"Invalid GUID format for ReminderId: {guidString}");
+            {
+                var guidString = reader.GetString();
+                if (!Guid.TryParse(guidString, out var guid))
+                    throw new JsonException($"Invalid GUID format for ReminderId: {guidString}");
 
-                    return ReminderId.Of(guid);
-                }
-            case JsonTokenType.StartObject:
-                {
-                    using var jsonDoc = JsonDocument.ParseValue(ref reader);
+                return ReminderId.Of(guid);
+            }
+        case JsonTokenType.StartObject:
+            {
+                using var jsonDoc = JsonDocument.ParseValue(ref reader);
 
-                    if (!jsonDoc.RootElement.TryGetProperty("id", out JsonElement idElement))
-                        throw new JsonException("Expected property 'id' not found.");
+                if (!jsonDoc.RootElement.TryGetProperty("id", out JsonElement idElement))
+                    throw new JsonException("Expected property 'id' not found.");
 
-                    var guidString = idElement.GetString();
+                var guidString = idElement.GetString();
 
-                    if (!Guid.TryParse(guidString, out var guid))
-                        throw new JsonException($"Invalid GUID format for ReminderId: {guidString}");
+                if (!Guid.TryParse(guidString, out var guid))
+                    throw new JsonException($"Invalid GUID format for ReminderId: {guidString}");
 
-                    return ReminderId.Of(guid);
-                }
+                return ReminderId.Of(guid);
+            }
             default:
                 throw new JsonException(
                     $"Unexpected token parsing ReminderId. Expected String or StartObject, got {reader.TokenType}.");

--- a/Backend/src/BuildingBlocks/BuildingBlocks.Domain/Reminders/Reminder/ValueObjects/ReminderId.cs
+++ b/Backend/src/BuildingBlocks/BuildingBlocks.Domain/Reminders/Reminder/ValueObjects/ReminderId.cs
@@ -29,7 +29,7 @@ public class ReminderIdJsonConverter : JsonConverter<ReminderId>
 
                 return ReminderId.Of(guid);
             }
-        case JsonTokenType.StartObject:
+            case JsonTokenType.StartObject:
             {
                 using var jsonDoc = JsonDocument.ParseValue(ref reader);
 

--- a/Backend/src/Modules/Nodes/Nodes.Application/Data/NodesService.cs
+++ b/Backend/src/Modules/Nodes/Nodes.Application/Data/NodesService.cs
@@ -1,7 +1,7 @@
 using BuildingBlocks.Application.Data;
 using BuildingBlocks.Domain.Nodes.Node.Dtos;
 using BuildingBlocks.Domain.Nodes.Node.ValueObjects;
-using BuildingBlocks.Domain.Reminders.ValueObjects;
+using BuildingBlocks.Domain.Reminders.Reminder.ValueObjects;
 using Mapster;
 using Microsoft.Extensions.DependencyInjection;
 using Nodes.Application.Data.Abstractions;

--- a/Backend/src/Modules/Nodes/Nodes.Domain/Models/Node.cs
+++ b/Backend/src/Modules/Nodes/Nodes.Domain/Models/Node.cs
@@ -1,7 +1,7 @@
 ﻿using System.Text.Json;
 using BuildingBlocks.Domain.Nodes.Node.Events;
 using BuildingBlocks.Domain.Nodes.Node.ValueObjects;
-using BuildingBlocks.Domain.Reminders.ValueObjects;
+using BuildingBlocks.Domain.Reminders.Reminder.ValueObjects;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Nodes.Domain.Models;

--- a/Backend/src/Modules/Reminders/Reminders.Api/Endpoints/Reminders/CreateReminder.cs
+++ b/Backend/src/Modules/Reminders/Reminders.Api/Endpoints/Reminders/CreateReminder.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using BuildingBlocks.Domain.Nodes.Node.ValueObjects;
-using BuildingBlocks.Domain.Reminders.ValueObjects;
+using BuildingBlocks.Domain.Reminders.Reminder.ValueObjects;
 using Reminders.Application.Entities.Reminders.Commands.CreateReminder;
 
 // ReSharper disable ClassNeverInstantiated.Global

--- a/Backend/src/Modules/Reminders/Reminders.Api/Endpoints/Reminders/GetReminderById.cs
+++ b/Backend/src/Modules/Reminders/Reminders.Api/Endpoints/Reminders/GetReminderById.cs
@@ -1,5 +1,5 @@
 ﻿using System.Text.Json.Serialization;
-using BuildingBlocks.Domain.Reminders.Dtos;
+using BuildingBlocks.Domain.Reminders.Reminder.Dtos;
 using Reminders.Application.Entities.Reminders.Queries.GetReminderById;
 
 namespace Reminders.Api.Endpoints.Reminders;

--- a/Backend/src/Modules/Reminders/Reminders.Api/Endpoints/Reminders/ListReminders.cs
+++ b/Backend/src/Modules/Reminders/Reminders.Api/Endpoints/Reminders/ListReminders.cs
@@ -1,5 +1,5 @@
 ﻿using BuildingBlocks.Application.Pagination;
-using BuildingBlocks.Domain.Reminders.Dtos;
+using BuildingBlocks.Domain.Reminders.Reminder.Dtos;
 using Reminders.Application.Entities.Reminders.Queries.ListReminders;
 
 namespace Reminders.Api.Endpoints.Reminders;

--- a/Backend/src/Modules/Reminders/Reminders.Application/Data/Abstractions/IRemindersRepository.cs
+++ b/Backend/src/Modules/Reminders/Reminders.Application/Data/Abstractions/IRemindersRepository.cs
@@ -1,4 +1,4 @@
-using BuildingBlocks.Domain.Reminders.ValueObjects;
+using BuildingBlocks.Domain.Reminders.Reminder.ValueObjects;
 
 namespace Reminders.Application.Data.Abstractions;
 

--- a/Backend/src/Modules/Reminders/Reminders.Application/Data/RemindersService.cs
+++ b/Backend/src/Modules/Reminders/Reminders.Application/Data/RemindersService.cs
@@ -1,6 +1,6 @@
 using BuildingBlocks.Application.Data;
-using BuildingBlocks.Domain.Reminders.Dtos;
-using BuildingBlocks.Domain.Reminders.ValueObjects;
+using BuildingBlocks.Domain.Reminders.Reminder.Dtos;
+using BuildingBlocks.Domain.Reminders.Reminder.ValueObjects;
 using Mapster;
 using Microsoft.Extensions.DependencyInjection;
 using Reminders.Application.Data.Abstractions;

--- a/Backend/src/Modules/Reminders/Reminders.Application/Entities/Reminders/Commands/CreateReminder/CreateReminderCommand.cs
+++ b/Backend/src/Modules/Reminders/Reminders.Application/Entities/Reminders/Commands/CreateReminder/CreateReminderCommand.cs
@@ -1,5 +1,5 @@
 ﻿using BuildingBlocks.Domain.Nodes.Node.ValueObjects;
-using BuildingBlocks.Domain.Reminders.ValueObjects;
+using BuildingBlocks.Domain.Reminders.Reminder.ValueObjects;
 
 namespace Reminders.Application.Entities.Reminders.Commands.CreateReminder;
 

--- a/Backend/src/Modules/Reminders/Reminders.Application/Entities/Reminders/Commands/CreateReminder/CreateReminderHandler.cs
+++ b/Backend/src/Modules/Reminders/Reminders.Application/Entities/Reminders/Commands/CreateReminder/CreateReminderHandler.cs
@@ -1,5 +1,5 @@
 ﻿using BuildingBlocks.Application.Data;
-using BuildingBlocks.Domain.Reminders.ValueObjects;
+using BuildingBlocks.Domain.Reminders.Reminder.ValueObjects;
 using Reminders.Application.Data.Abstractions;
 
 namespace Reminders.Application.Entities.Reminders.Commands.CreateReminder;

--- a/Backend/src/Modules/Reminders/Reminders.Application/Entities/Reminders/Commands/DeleteReminder/DeleteReminderCommand.cs
+++ b/Backend/src/Modules/Reminders/Reminders.Application/Entities/Reminders/Commands/DeleteReminder/DeleteReminderCommand.cs
@@ -1,4 +1,4 @@
-﻿using BuildingBlocks.Domain.Reminders.ValueObjects;
+﻿using BuildingBlocks.Domain.Reminders.Reminder.ValueObjects;
 
 namespace Reminders.Application.Entities.Reminders.Commands.DeleteReminder;
 

--- a/Backend/src/Modules/Reminders/Reminders.Application/Entities/Reminders/Extensions/ReminderExtensions.cs
+++ b/Backend/src/Modules/Reminders/Reminders.Application/Entities/Reminders/Extensions/ReminderExtensions.cs
@@ -1,5 +1,5 @@
 ﻿using BuildingBlocks.Domain.Nodes.Node.Dtos;
-using BuildingBlocks.Domain.Reminders.Dtos;
+using BuildingBlocks.Domain.Reminders.Reminder.Dtos;
 
 namespace Reminders.Application.Entities.Reminders.Extensions;
 

--- a/Backend/src/Modules/Reminders/Reminders.Application/Entities/Reminders/Queries/GetReminderById/GetReminderByIdQuery.cs
+++ b/Backend/src/Modules/Reminders/Reminders.Application/Entities/Reminders/Queries/GetReminderById/GetReminderByIdQuery.cs
@@ -1,7 +1,7 @@
 ﻿// ReSharper disable ClassNeverInstantiated.Global
 
-using BuildingBlocks.Domain.Reminders.Dtos;
-using BuildingBlocks.Domain.Reminders.ValueObjects;
+using BuildingBlocks.Domain.Reminders.Reminder.Dtos;
+using BuildingBlocks.Domain.Reminders.Reminder.ValueObjects;
 
 namespace Reminders.Application.Entities.Reminders.Queries.GetReminderById;
 

--- a/Backend/src/Modules/Reminders/Reminders.Application/Entities/Reminders/Queries/ListReminders/ListRemindersHandler.cs
+++ b/Backend/src/Modules/Reminders/Reminders.Application/Entities/Reminders/Queries/ListReminders/ListRemindersHandler.cs
@@ -1,6 +1,6 @@
 ﻿using BuildingBlocks.Application.Data;
 using BuildingBlocks.Application.Pagination;
-using BuildingBlocks.Domain.Reminders.Dtos;
+using BuildingBlocks.Domain.Reminders.Reminder.Dtos;
 using Reminders.Application.Data.Abstractions;
 using Reminders.Application.Entities.Reminders.Extensions;
 

--- a/Backend/src/Modules/Reminders/Reminders.Application/Entities/Reminders/Queries/ListReminders/ListRemindersQuery.cs
+++ b/Backend/src/Modules/Reminders/Reminders.Application/Entities/Reminders/Queries/ListReminders/ListRemindersQuery.cs
@@ -1,5 +1,5 @@
 ﻿using BuildingBlocks.Application.Pagination;
-using BuildingBlocks.Domain.Reminders.Dtos;
+using BuildingBlocks.Domain.Reminders.Reminder.Dtos;
 
 // ReSharper disable ClassNeverInstantiated.Global
 

--- a/Backend/src/Modules/Reminders/Reminders.Domain/Events/ReminderCreatedEvent.cs
+++ b/Backend/src/Modules/Reminders/Reminders.Domain/Events/ReminderCreatedEvent.cs
@@ -1,5 +1,0 @@
-﻿using Reminders.Domain.Models;
-
-namespace Reminders.Domain.Events;
-
-public record ReminderCreatedEvent(Reminder Reminder) : IDomainEvent;

--- a/Backend/src/Modules/Reminders/Reminders.Domain/Events/ReminderUpdatedEvent.cs
+++ b/Backend/src/Modules/Reminders/Reminders.Domain/Events/ReminderUpdatedEvent.cs
@@ -1,5 +1,0 @@
-﻿using Reminders.Domain.Models;
-
-namespace Reminders.Domain.Events;
-
-public record ReminderUpdatedEvent(Reminder Reminder) : IDomainEvent;

--- a/Backend/src/Modules/Reminders/Reminders.Domain/Models/Reminder.cs
+++ b/Backend/src/Modules/Reminders/Reminders.Domain/Models/Reminder.cs
@@ -1,5 +1,5 @@
 ﻿using BuildingBlocks.Domain.Nodes.Node.ValueObjects;
-using BuildingBlocks.Domain.Reminders.ValueObjects;
+using BuildingBlocks.Domain.Reminders.Reminder.ValueObjects;
 using Reminders.Domain.Events;
 
 namespace Reminders.Domain.Models;

--- a/Backend/src/Modules/Reminders/Reminders.Domain/Models/Reminder.cs
+++ b/Backend/src/Modules/Reminders/Reminders.Domain/Models/Reminder.cs
@@ -1,6 +1,6 @@
 ﻿using BuildingBlocks.Domain.Nodes.Node.ValueObjects;
+using BuildingBlocks.Domain.Reminders.Reminder.Events;
 using BuildingBlocks.Domain.Reminders.Reminder.ValueObjects;
-using Reminders.Domain.Events;
 
 namespace Reminders.Domain.Models;
 
@@ -30,7 +30,7 @@ public class Reminder : Aggregate<ReminderId>
             NodeId = nodeId
         };
 
-        reminder.AddDomainEvent(new ReminderCreatedEvent(reminder));
+        reminder.AddDomainEvent(new ReminderCreatedEvent(reminder.Id));
 
         return reminder;
     }
@@ -44,7 +44,7 @@ public class Reminder : Aggregate<ReminderId>
         NotificationTime = notificationTime;
         Status = status;
 
-        AddDomainEvent(new ReminderUpdatedEvent(this));
+        AddDomainEvent(new ReminderUpdatedEvent(Id));
     }
 
     #endregion

--- a/Backend/src/Modules/Reminders/Reminders.Infrastructure/Data/Configurations/ReminderConfiguration.cs
+++ b/Backend/src/Modules/Reminders/Reminders.Infrastructure/Data/Configurations/ReminderConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using BuildingBlocks.Domain.Reminders.ValueObjects;
+﻿using BuildingBlocks.Domain.Reminders.Reminder.ValueObjects;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Reminders.Infrastructure.Data.Configurations;

--- a/Backend/src/Modules/Reminders/Reminders.Infrastructure/Data/Extensions/InitialData.cs
+++ b/Backend/src/Modules/Reminders/Reminders.Infrastructure/Data/Extensions/InitialData.cs
@@ -1,5 +1,5 @@
 ﻿using BuildingBlocks.Domain.Nodes.Node.ValueObjects;
-using BuildingBlocks.Domain.Reminders.ValueObjects;
+using BuildingBlocks.Domain.Reminders.Reminder.ValueObjects;
 
 namespace Reminders.Infrastructure.Data.Extensions;
 

--- a/Backend/src/Modules/Reminders/Reminders.Infrastructure/Data/Repositories/RemindersRepository.cs
+++ b/Backend/src/Modules/Reminders/Reminders.Infrastructure/Data/Repositories/RemindersRepository.cs
@@ -1,4 +1,4 @@
-using BuildingBlocks.Domain.Reminders.ValueObjects;
+using BuildingBlocks.Domain.Reminders.Reminder.ValueObjects;
 using Reminders.Application.Data.Abstractions;
 using Reminders.Application.Entities.Reminders.Exceptions;
 


### PR DESCRIPTION
In this PR I did the following:
- Moved the `Dtos` and `ValueObjects` folders into a newly created `Reminders\Reminder` folder to be consistent with other modules folder structure
- Moved the `Events` folder from the domain to building blocks

I decided to make a new PR because a lot of files are affected and didn't want to mix it with the new task where I noticed this omission

Before:
![image](https://github.com/user-attachments/assets/de597051-6726-4ca7-849a-efdcd753b5f1)

After:
![image](https://github.com/user-attachments/assets/05f2c5ae-018b-423b-b0f3-972aff9d1b9e)
