### PR TITLE
Fix: Remove Duplicate Registration in Nodes Service Collection Extensions 

### DIFF
--- a/Backend/src/Modules/Nodes/Nodes.Application/Extensions/ServiceCollectionExtensions.cs
+++ b/Backend/src/Modules/Nodes/Nodes.Application/Extensions/ServiceCollectionExtensions.cs
@@ -17,8 +17,6 @@ public static class ServiceCollectionExtensions
         
         services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());
 
-        services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());
-
         return services;
     }
 }


### PR DESCRIPTION
In this PR I removed the duplicate service registration

![image](https://github.com/user-attachments/assets/a9c44b70-52ad-4f34-93e7-6b6654e48bd5)
