### PR TITLE
Remove `version` from `docker-compose.yml` & `docker-compose.override.yml`

### DIFF
--- a/Backend/src/DockerCompose/docker-compose.override.yml
+++ b/Backend/src/DockerCompose/docker-compose.override.yml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 services: 
   core.db:
     environment:

--- a/Backend/src/DockerCompose/docker-compose.yml
+++ b/Backend/src/DockerCompose/docker-compose.yml
@@ -1,6 +1,4 @@
-﻿version: "3.4"
-
-name: timelines
+﻿name: timelines
 
 services:
   core.db:


### PR DESCRIPTION
In this PR `version` was removed from `docker-compose.yml` & `docker-compose.override.yml` files to get rid of the 

```
the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
``` 

message from the terminal