### PR TITLE
Add CodeAnalysis.CSharp.Workspaces reference and update CodeAnalysis dependencies to 4.13.0

### DIFF
--- a/Backend/src/Applications/Core/Core.Api/Core.Api.csproj
+++ b/Backend/src/Applications/Core/Core.Api/Core.Api.csproj
@@ -27,12 +27,13 @@
     <ItemGroup>
         <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
         <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.4">
+        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.13.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.13.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
-        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.11.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
In this PR I have added the `Microsoft.CodeAnalysis.CSharp.Workspaces` reference and updated `Microsoft.CodeAnalysis.Common` to `4.13.0`. This fixes the error that produces the following trace when attempting to create migrations:
```shell
System.TypeLoadException: Method 'get_IsParamsArray' in type 'Microsoft.CodeAnalysis.CodeGeneration.CodeGenerationParameterSymbol' from assembly 'Microsoft.CodeAnalysis.Workspaces, Version=4.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35' does not have an implementation.
System.TypeLoadException: Method 'get_PartialDefinitionPart' in type 'Microsoft.CodeAnalysis.CodeGeneration.CodeGenerationPropertySymbol' from assembly 'Microsoft.CodeAnalysis.Workspaces, Version=4.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35' does not have an implementation.
System.TypeLoadException: Method 'get_AllowsRefLikeType' in type 'Microsoft.CodeAnalysis.CodeGeneration.CodeGenerationTypeParameterSymbol' from assembly 'Microsoft.CodeAnalysis.Workspaces, Version=4.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35' does not have an implementation.
Unable to load one or more of the requested types.
Method 'get_IsParamsArray' in type 'Microsoft.CodeAnalysis.CodeGeneration.CodeGenerationParameterSymbol' from assembly 'Microsoft.CodeAnalysis.Workspaces, Version=4.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35' does not have an implementation.
Method 'get_PartialDefinitionPart' in type 'Microsoft.CodeAnalysis.CodeGeneration.CodeGenerationPropertySymbol' from assembly 'Microsoft.CodeAnalysis.Workspaces, Version=4.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35' does not have an implementation.
Method 'get_AllowsRefLikeType' in type 'Microsoft.CodeAnalysis.CodeGeneration.CodeGenerationTypeParameterSymbol' from assembly 'Microsoft.CodeAnalysis.Workspaces, Version=4.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35' does not have an implementation.
```