### PR TITLE
Align Count Methods with Paginated Results by Excluding Soft-Deleted Entities

### DIFF
--- a/Backend/src/BuildingBlocks/BuildingBlocks.Application/Data/IFilesService.cs
+++ b/Backend/src/BuildingBlocks/BuildingBlocks.Application/Data/IFilesService.cs
@@ -10,8 +10,8 @@ public interface IFilesService
     Task<List<FileAssetBaseDto>> ListFileAssetsByNodeIdPaginated(NodeId nodeId, int pageIndex, int pageSize, CancellationToken cancellationToken);
     Task<FileAssetDto> GetFileAssetByIdAsync(FileAssetId fileAssetId, CancellationToken cancellationToken);
     Task<FileAssetBaseDto> GetFileAssetBaseByIdAsync(FileAssetId fileAssetId, CancellationToken cancellationToken);
-    Task<long> CountFileAssetsAsync(CancellationToken cancellationToken);
-    Task<long> CountFileAssetsByNodeIdAsync(NodeId nodeId, CancellationToken cancellationToken);
+    Task<long> CountAllFileAssetsAsync(CancellationToken cancellationToken);
+    Task<long> CountAllFileAssetsByNodeIdAsync(NodeId nodeId, CancellationToken cancellationToken);
 
     Task DeleteFileAsset(FileAssetId fileAssetId, CancellationToken cancellationToken);
     Task DeleteFiles(NodeId nodeId, IEnumerable<FileAssetId> fileAssetIds, CancellationToken cancellationToken);

--- a/Backend/src/BuildingBlocks/BuildingBlocks.Application/Data/INodesService.cs
+++ b/Backend/src/BuildingBlocks/BuildingBlocks.Application/Data/INodesService.cs
@@ -13,8 +13,8 @@ public interface INodesService
     Task<List<NodeBaseDto>> ListNodesByTimelineIdPaginated(TimelineId timelineId, int pageIndex, int pageSize, CancellationToken cancellationToken);
     Task<List<NodeBaseDto>> ListNodesBelongingToPhasePaginated(DateTime startDate, DateTime? endDate, int pageIndex, int pageSize, CancellationToken cancellationToken);
     Task<List<NodeBaseDto>> GetNodesByIdsAsync(IEnumerable<NodeId> nodeIds, CancellationToken cancellationToken);
-    Task<long> CountNodesAsync(CancellationToken cancellationToken);
-    Task<long> CountNodesByTimelineIdAsync(TimelineId timelineId, CancellationToken cancellationToken);
+    Task<long> CountAllNodesAsync(CancellationToken cancellationToken);
+    Task<long> CountAllNodesByTimelineIdAsync(TimelineId timelineId, CancellationToken cancellationToken);
     Task<long> CountNodesBelongingToPhase(DateTime startDate, DateTime? endDate, CancellationToken cancellationToken);
     Task EnsureNodeBelongsToOwner(NodeId nodeId, CancellationToken cancellationToken);
 

--- a/Backend/src/BuildingBlocks/BuildingBlocks.Application/Data/INotesService.cs
+++ b/Backend/src/BuildingBlocks/BuildingBlocks.Application/Data/INotesService.cs
@@ -10,8 +10,8 @@ public interface INotesService
     Task<List<NoteBaseDto>> ListNotesByNodeIdPaginated(NodeId nodeId, int pageIndex, int pageSize, CancellationToken cancellationToken);
     Task<NoteDto> GetNoteByIdAsync(NoteId noteId, CancellationToken cancellationToken);
     Task<NoteBaseDto> GetNoteBaseByIdAsync(NoteId noteId, CancellationToken cancellationToken);
-    Task<long> CountNotesAsync(CancellationToken cancellationToken);
-    Task<long> CountNotesByNodeIdAsync(NodeId nodeId, CancellationToken cancellationToken);
+    Task<long> CountAllNotesAsync(CancellationToken cancellationToken);
+    Task<long> CountAllNotesByNodeIdAsync(NodeId nodeId, CancellationToken cancellationToken);
 
     Task DeleteNote(NoteId noteId, CancellationToken cancellationToken);
     Task DeleteNotes(NodeId nodeId, IEnumerable<NoteId> noteIds, CancellationToken cancellationToken);

--- a/Backend/src/BuildingBlocks/BuildingBlocks.Application/Data/IRemindersService.cs
+++ b/Backend/src/BuildingBlocks/BuildingBlocks.Application/Data/IRemindersService.cs
@@ -11,8 +11,8 @@ public interface IRemindersService
     Task<ReminderDto> GetReminderByIdAsync(ReminderId reminderId, CancellationToken cancellationToken);
     Task<ReminderBaseDto> GetReminderBaseByIdAsync(ReminderId reminderId, CancellationToken cancellationToken);
     Task<List<ReminderBaseDto>> GetRemindersBaseBelongingToNodeIdsAsync(IEnumerable<NodeId> nodeIds, CancellationToken cancellationToken);
-    Task<long> CountRemindersAsync(CancellationToken cancellationToken);
-    Task<long> CountRemindersByNodeIdAsync(NodeId nodeId, CancellationToken cancellationToken);
+    Task<long> CountAllRemindersAsync(CancellationToken cancellationToken);
+    Task<long> CountAllRemindersByNodeIdAsync(NodeId nodeId, CancellationToken cancellationToken);
 
     Task DeleteReminder(ReminderId reminderId, CancellationToken cancellationToken);
     Task DeleteReminders(NodeId nodeId, IEnumerable<ReminderId> reminderIds, CancellationToken cancellationToken);

--- a/Backend/src/BuildingBlocks/BuildingBlocks.Application/Data/ITimelinesService.cs
+++ b/Backend/src/BuildingBlocks/BuildingBlocks.Application/Data/ITimelinesService.cs
@@ -11,7 +11,7 @@ public interface ITimelinesService
     Task<List<TimelineDto>> ListTimelinesPaginated(int pageIndex, int pageSize, CancellationToken cancellationToken);
     Task<TimelineDto> GetTimelineByIdAsync(TimelineId timelineId, CancellationToken cancellationToken);
     Task<TimelineBaseDto> GetTimelineBaseByIdAsync(TimelineId timelineId, CancellationToken cancellationToken);
-    Task<long> CountTimelinesAsync(CancellationToken cancellationToken);
+    Task<long> CountAllTimelinesAsync(CancellationToken cancellationToken);
     Task EnsureTimelineBelongsToOwner(TimelineId timelineId, CancellationToken cancellationToken);
 
     Task AddNode(TimelineId timelineId, NodeId nodeId, CancellationToken cancellationToken);

--- a/Backend/src/Modules/Files/Files.Application/Data/Abstractions/IFilesRepository.cs
+++ b/Backend/src/Modules/Files/Files.Application/Data/Abstractions/IFilesRepository.cs
@@ -11,8 +11,8 @@ public interface IFilesRepository
     Task<List<FileAsset>> ListFileAssetsByNodeIdPaginatedAsync(NodeId nodeId, int pageIndex, int pageSize, CancellationToken cancellationToken);
     Task<FileAsset> GetFileAssetByIdAsync(FileAssetId fileAssetId, CancellationToken cancellationToken);
     Task UpdateFileAssetAsync(FileAsset fileAsset, CancellationToken cancellationToken);
-    Task<long> FileAssetCountAsync(CancellationToken cancellationToken);
-    Task<long> FileAssetCountByNodeIdAsync(NodeId nodeId, CancellationToken cancellationToken);
+    Task<long> CountAllFileAssetsAsync(CancellationToken cancellationToken);
+    Task<long> CountAllFileAssetsByNodeIdAsync(NodeId nodeId, CancellationToken cancellationToken);
 
     Task DeleteFileAsset(FileAssetId fileAssetId, CancellationToken cancellationToken);
     Task DeleteFileAssets(IEnumerable<FileAssetId> fileAssetIds, CancellationToken cancellationToken);

--- a/Backend/src/Modules/Files/Files.Application/Data/FilesService.cs
+++ b/Backend/src/Modules/Files/Files.Application/Data/FilesService.cs
@@ -57,14 +57,14 @@ public class FilesService(IServiceProvider serviceProvider, IFilesRepository fil
         return fileBaseDto;
     }
 
-    public async Task<long> CountFileAssetsAsync(CancellationToken cancellationToken)
+    public async Task<long> CountAllFileAssetsAsync(CancellationToken cancellationToken)
     {
-        return await filesRepository.FileAssetCountAsync(cancellationToken);
+        return await filesRepository.CountAllFileAssetsAsync(cancellationToken);
     }
 
-    public async Task<long> CountFileAssetsByNodeIdAsync(NodeId nodeId, CancellationToken cancellationToken)
+    public async Task<long> CountAllFileAssetsByNodeIdAsync(NodeId nodeId, CancellationToken cancellationToken)
     {
-        return await filesRepository.FileAssetCountByNodeIdAsync(nodeId, cancellationToken);
+        return await filesRepository.CountAllFileAssetsByNodeIdAsync(nodeId, cancellationToken);
     }
 
     public async Task DeleteFileAsset(FileAssetId fileAssetId, CancellationToken cancellationToken)

--- a/Backend/src/Modules/Files/Files.Application/Entities/Files/Queries/ListFileAssets/ListFileAssetsHandler.cs
+++ b/Backend/src/Modules/Files/Files.Application/Entities/Files/Queries/ListFileAssets/ListFileAssetsHandler.cs
@@ -11,15 +11,13 @@ public class ListFileAssetsHandler(IFilesService filesService) : IQueryHandler<L
         var pageIndex = query.PaginationRequest.PageIndex;
         var pageSize = query.PaginationRequest.PageSize;
 
-        var totalCount = await filesService.CountFileAssetsAsync(cancellationToken);
-
         var fileAssets = await filesService.ListFileAssetsPaginated(pageIndex, pageSize, cancellationToken);
 
         return new ListFileAssetsResult(
             new PaginatedResult<FileAssetDto>(
                 pageIndex,
                 pageSize,
-                totalCount,
+                fileAssets.Count,
                 fileAssets));
     }
 }

--- a/Backend/src/Modules/Files/Files.Infrastructure/Data/Repositories/FilesRepository.cs
+++ b/Backend/src/Modules/Files/Files.Infrastructure/Data/Repositories/FilesRepository.cs
@@ -29,7 +29,7 @@ public class FilesRepository(ICurrentUser currentUser, IFilesDbContext dbContext
     {
         return await dbContext.FileAssets
             .AsNoTracking()
-            .Where(f => f.NodeId == nodeId && f.OwnerId == currentUser.UserId! && f.IsDeleted == false)
+            .Where(f => f.NodeId == nodeId && f.OwnerId == currentUser.UserId! && !f.IsDeleted)
             .OrderBy(f => f.CreatedAt)
             .Skip(pageIndex * pageSize)
             .Take(pageSize)

--- a/Backend/src/Modules/Files/Files.Infrastructure/Data/Repositories/FilesRepository.cs
+++ b/Backend/src/Modules/Files/Files.Infrastructure/Data/Repositories/FilesRepository.cs
@@ -50,14 +50,14 @@ public class FilesRepository(ICurrentUser currentUser, IFilesDbContext dbContext
         await dbContext.SaveChangesAsync(cancellationToken);
     }
 
-    public async Task<long> FileAssetCountAsync(CancellationToken cancellationToken)
+    public async Task<long> CountAllFileAssetsAsync(CancellationToken cancellationToken)
     {
         return await dbContext.FileAssets
             .Where(f => f.OwnerId == currentUser.UserId!)
             .LongCountAsync(cancellationToken);
     }
 
-    public async Task<long> FileAssetCountByNodeIdAsync(NodeId nodeId, CancellationToken cancellationToken)
+    public async Task<long> CountAllFileAssetsByNodeIdAsync(NodeId nodeId, CancellationToken cancellationToken)
     {
         return await dbContext.FileAssets
             .Where(f => f.OwnerId == currentUser.UserId!)

--- a/Backend/src/Modules/Nodes/Nodes.Application/Data/Abstractions/INodesRepository.cs
+++ b/Backend/src/Modules/Nodes/Nodes.Application/Data/Abstractions/INodesRepository.cs
@@ -8,8 +8,8 @@ public interface INodesRepository
     Task<List<Node>> ListNodesPaginatedAsync(int pageIndex, int pageSize, CancellationToken cancellationToken);
     Task<List<Node>> ListNodesByTimelineIdPaginatedAsync(TimelineId timelineId, int pageIndex, int pageSize, CancellationToken cancellationToken);
     Task<List<Node>> ListNodesBelongingToPhaseAsync(DateTime startDate, DateTime? endDate, int pageIndex, int pageSize, CancellationToken cancellationToken);
-    Task<long> NodeCountAsync(CancellationToken cancellationToken);
-    Task<long> NodeCountByTimelineIdAsync(TimelineId timelineId, CancellationToken cancellationToken);
+    Task<long> CountAllNodesAsync(CancellationToken cancellationToken);
+    Task<long> CountAllNodesByTimelineIdAsync(TimelineId timelineId, CancellationToken cancellationToken);
     Task<long> NodeCountBelongingToPhase(DateTime startDate, DateTime? endDate, CancellationToken cancellationToken);
 
     Task<Node> GetNodeByIdAsync(NodeId nodeId, CancellationToken cancellationToken);

--- a/Backend/src/Modules/Nodes/Nodes.Application/Data/NodesService.cs
+++ b/Backend/src/Modules/Nodes/Nodes.Application/Data/NodesService.cs
@@ -120,14 +120,14 @@ public class NodesService(IServiceProvider serviceProvider, INodesRepository nod
             .ToList();
     }
 
-    public async Task<long> CountNodesAsync(CancellationToken cancellationToken)
+    public async Task<long> CountAllNodesAsync(CancellationToken cancellationToken)
     {
-        return await nodesRepository.NodeCountAsync(cancellationToken);
+        return await nodesRepository.CountAllNodesAsync(cancellationToken);
     }
 
-    public async Task<long> CountNodesByTimelineIdAsync(TimelineId timelineId, CancellationToken cancellationToken)
+    public async Task<long> CountAllNodesByTimelineIdAsync(TimelineId timelineId, CancellationToken cancellationToken)
     {
-        return await nodesRepository.NodeCountByTimelineIdAsync(timelineId, cancellationToken);
+        return await nodesRepository.CountAllNodesByTimelineIdAsync(timelineId, cancellationToken);
     }
 
     public async Task<long> CountNodesBelongingToPhase(DateTime startDate, DateTime? endDate, CancellationToken cancellationToken)

--- a/Backend/src/Modules/Nodes/Nodes.Application/Entities/Nodes/Queries/ListFileAssetsByNodeId/ListFileAssetsByNodeIdHandler.cs
+++ b/Backend/src/Modules/Nodes/Nodes.Application/Entities/Nodes/Queries/ListFileAssetsByNodeId/ListFileAssetsByNodeIdHandler.cs
@@ -11,15 +11,13 @@ public class ListFileAssetsByNodeIdHandler(IFilesService filesService) : IQueryH
         var pageIndex = query.PaginationRequest.PageIndex;
         var pageSize = query.PaginationRequest.PageSize;
 
-        var totalCount = await filesService.CountFileAssetsByNodeIdAsync(query.Id, cancellationToken);
-
         var fileAssets = await filesService.ListFileAssetsByNodeIdPaginated(query.Id, pageIndex, pageSize, cancellationToken);
 
         return new ListFileAssetsByNodeIdResult(
             new PaginatedResult<FileAssetBaseDto>(
                 pageIndex,
                 pageSize,
-                totalCount,
+                fileAssets.Count,
                 fileAssets));
     }
 }

--- a/Backend/src/Modules/Nodes/Nodes.Application/Entities/Nodes/Queries/ListNodes/ListNodesHandler.cs
+++ b/Backend/src/Modules/Nodes/Nodes.Application/Entities/Nodes/Queries/ListNodes/ListNodesHandler.cs
@@ -11,15 +11,13 @@ internal class ListNodesHandler(INodesService nodesService) : IQueryHandler<List
         var pageIndex = query.PaginationRequest.PageIndex;
         var pageSize = query.PaginationRequest.PageSize;
 
-        var totalCount = await nodesService.CountNodesAsync(cancellationToken);
-
         var nodes = await nodesService.ListNodesPaginated(pageIndex, pageSize, cancellationToken);
 
         return new ListNodesResult(
             new PaginatedResult<NodeDto>(
                 pageIndex,
                 pageSize,
-                totalCount,
+                nodes.Count,
                 nodes));
     }
 }

--- a/Backend/src/Modules/Nodes/Nodes.Application/Entities/Nodes/Queries/ListNotesByNodeId/ListNotesByNodeIdHandler.cs
+++ b/Backend/src/Modules/Nodes/Nodes.Application/Entities/Nodes/Queries/ListNotesByNodeId/ListNotesByNodeIdHandler.cs
@@ -11,15 +11,13 @@ public class ListNotesByNodeIdHandler(INotesService notesService) : IQueryHandle
         var pageIndex = query.PaginationRequest.PageIndex;
         var pageSize = query.PaginationRequest.PageSize;
 
-        var totalCount = await notesService.CountNotesByNodeIdAsync(query.Id, cancellationToken);
-
-        var fileAssets = await notesService.ListNotesByNodeIdPaginated(query.Id, pageIndex, pageSize, cancellationToken);
+        var notes = await notesService.ListNotesByNodeIdPaginated(query.Id, pageIndex, pageSize, cancellationToken);
 
         return new ListNotesByNodeIdResult(
             new PaginatedResult<NoteBaseDto>(
                 pageIndex,
                 pageSize,
-                totalCount,
-                fileAssets));
+                notes.Count,
+                notes));
     }
 }

--- a/Backend/src/Modules/Nodes/Nodes.Application/Entities/Nodes/Queries/ListRemindersByNodeId/ListRemindersByNodeIdHandler.cs
+++ b/Backend/src/Modules/Nodes/Nodes.Application/Entities/Nodes/Queries/ListRemindersByNodeId/ListRemindersByNodeIdHandler.cs
@@ -11,15 +11,13 @@ public class ListRemindersByNodeIdHandler(IRemindersService remindersService) : 
         var pageIndex = query.PaginationRequest.PageIndex;
         var pageSize = query.PaginationRequest.PageSize;
 
-        var totalCount = await remindersService.CountRemindersByNodeIdAsync(query.Id, cancellationToken);
-
-        var fileAssets = await remindersService.ListRemindersByNodeIdPaginated(query.Id, pageIndex, pageSize, cancellationToken);
+        var reminders = await remindersService.ListRemindersByNodeIdPaginated(query.Id, pageIndex, pageSize, cancellationToken);
 
         return new ListRemindersByNodeIdResult(
             new PaginatedResult<ReminderBaseDto>(
                 pageIndex,
                 pageSize,
-                totalCount,
-                fileAssets));
+                reminders.Count,
+                reminders));
     }
 }

--- a/Backend/src/Modules/Nodes/Nodes.Infrastructure/Data/Repositories/NodesRepository.cs
+++ b/Backend/src/Modules/Nodes/Nodes.Infrastructure/Data/Repositories/NodesRepository.cs
@@ -43,14 +43,14 @@ public class NodesRepository(ICurrentUser currentUser, INodesDbContext dbContext
             .ToListAsync(cancellationToken);
     }
 
-    public async Task<long> NodeCountAsync(CancellationToken cancellationToken)
+    public async Task<long> CountAllNodesAsync(CancellationToken cancellationToken)
     {
         return await dbContext.Nodes
             .Where(n => n.OwnerId == currentUser.UserId! && n.IsDeleted == false)
             .LongCountAsync(cancellationToken);
     }
 
-    public async Task<long> NodeCountByTimelineIdAsync(TimelineId timelineId, CancellationToken cancellationToken)
+    public async Task<long> CountAllNodesByTimelineIdAsync(TimelineId timelineId, CancellationToken cancellationToken)
     {
         return await dbContext.Nodes.LongCountAsync(n => n.TimelineId == timelineId && n.IsDeleted == false, cancellationToken);
     }

--- a/Backend/src/Modules/Nodes/Nodes.Infrastructure/Data/Repositories/NodesRepository.cs
+++ b/Backend/src/Modules/Nodes/Nodes.Infrastructure/Data/Repositories/NodesRepository.cs
@@ -24,7 +24,7 @@ public class NodesRepository(ICurrentUser currentUser, INodesDbContext dbContext
     {
         return await dbContext.Nodes
             .AsNoTracking()
-            .Where(n => n.TimelineId == timelineId && n.IsDeleted == false)
+            .Where(n => n.TimelineId == timelineId && !n.IsDeleted)
             .OrderBy(f => f.CreatedAt)
             .Skip(pageIndex * pageSize)
             .Take(pageSize)

--- a/Backend/src/Modules/Notes/Notes.Application/Data/Abstractions/INotesRepository.cs
+++ b/Backend/src/Modules/Notes/Notes.Application/Data/Abstractions/INotesRepository.cs
@@ -9,8 +9,8 @@ public interface INotesRepository
 
     Task<List<Note>> ListNotesPaginatedAsync(int pageIndex, int pageSize, CancellationToken cancellationToken);
     Task<List<Note>> ListNotesByNodeIdPaginatedAsync(NodeId nodeId, int pageIndex, int pageSize, CancellationToken cancellationToken);
-    Task<long> NoteCountAsync(CancellationToken cancellationToken);
-    Task<long> NoteCountByNodeIdAsync(NodeId nodeId, CancellationToken cancellationToken);
+    Task<long> CountAllNotesAsync(CancellationToken cancellationToken);
+    Task<long> CountAllNotesByNodeIdAsync(NodeId nodeId, CancellationToken cancellationToken);
 
     Task<Note> GetNoteByIdAsync(NoteId noteId, CancellationToken cancellationToken);
     Task<List<Note>> GetNotesByIdsAsync(IEnumerable<NoteId> noteIds, CancellationToken cancellationToken);

--- a/Backend/src/Modules/Notes/Notes.Application/Data/NotesService.cs
+++ b/Backend/src/Modules/Notes/Notes.Application/Data/NotesService.cs
@@ -61,9 +61,9 @@ public class NotesService(INotesRepository notesRepository, IServiceProvider ser
         return noteBaseDto;
     }
 
-    public async Task<long> CountNotesByNodeIdAsync(NodeId nodeId, CancellationToken cancellationToken)
+    public async Task<long> CountAllNotesByNodeIdAsync(NodeId nodeId, CancellationToken cancellationToken)
     {
-        return await notesRepository.NoteCountByNodeIdAsync(nodeId, cancellationToken);
+        return await notesRepository.CountAllNotesByNodeIdAsync(nodeId, cancellationToken);
     }
 
     public async Task DeleteNote(NoteId noteId, CancellationToken cancellationToken)
@@ -93,8 +93,8 @@ public class NotesService(INotesRepository notesRepository, IServiceProvider ser
         return noteBaseDtos;
     }
 
-    public async Task<long> CountNotesAsync(CancellationToken cancellationToken)
+    public async Task<long> CountAllNotesAsync(CancellationToken cancellationToken)
     {
-        return await notesRepository.NoteCountAsync(cancellationToken);
+        return await notesRepository.CountAllNotesAsync(cancellationToken);
     }
 }

--- a/Backend/src/Modules/Notes/Notes.Application/Entities/Notes/Queries/ListNotes/ListNotesHandler.cs
+++ b/Backend/src/Modules/Notes/Notes.Application/Entities/Notes/Queries/ListNotes/ListNotesHandler.cs
@@ -11,15 +11,13 @@ internal class ListNotesHandler(INotesService notesService) : IQueryHandler<List
         var pageIndex = query.PaginationRequest.PageIndex;
         var pageSize = query.PaginationRequest.PageSize;
 
-        var totalCount = await notesService.CountNotesAsync(cancellationToken);
-
         var notes = await notesService.ListNotesPaginated(pageIndex, pageSize, cancellationToken);
 
         return new ListNotesResult(
             new PaginatedResult<NoteDto>(
                 pageIndex,
                 pageSize,
-                totalCount,
+                notes.Count,
                 notes));
     }
 }

--- a/Backend/src/Modules/Notes/Notes.Infrastructure/Data/Repositories/NotesRepository.cs
+++ b/Backend/src/Modules/Notes/Notes.Infrastructure/Data/Repositories/NotesRepository.cs
@@ -30,7 +30,7 @@ public class NotesRepository(ICurrentUser currentUser, INotesDbContext dbContext
     {
         return await dbContext.Notes
             .AsNoTracking()
-            .Where(n => n.NodeId == nodeId && n.OwnerId == currentUser.UserId!)
+            .Where(n => n.NodeId == nodeId && n.OwnerId == currentUser.UserId! && !n.IsDeleted)
             .OrderBy(n => n.CreatedAt)
             .Skip(pageIndex * pageSize)
             .Take(pageSize)

--- a/Backend/src/Modules/Notes/Notes.Infrastructure/Data/Repositories/NotesRepository.cs
+++ b/Backend/src/Modules/Notes/Notes.Infrastructure/Data/Repositories/NotesRepository.cs
@@ -37,14 +37,14 @@ public class NotesRepository(ICurrentUser currentUser, INotesDbContext dbContext
             .ToListAsync(cancellationToken);
     }
 
-    public async Task<long> NoteCountAsync(CancellationToken cancellationToken)
+    public async Task<long> CountAllNotesAsync(CancellationToken cancellationToken)
     {
         return await dbContext.Notes
             .Where(n => n.OwnerId == currentUser.UserId!)
             .LongCountAsync(cancellationToken);
     }
 
-    public async Task<long> NoteCountByNodeIdAsync(NodeId nodeId, CancellationToken cancellationToken)
+    public async Task<long> CountAllNotesByNodeIdAsync(NodeId nodeId, CancellationToken cancellationToken)
     {
         return await dbContext.Notes
             .Where(n => n.OwnerId == currentUser.UserId!)

--- a/Backend/src/Modules/Reminders/Reminders.Application/Data/Abstractions/IRemindersRepository.cs
+++ b/Backend/src/Modules/Reminders/Reminders.Application/Data/Abstractions/IRemindersRepository.cs
@@ -10,8 +10,8 @@ public interface IRemindersRepository
     Task<List<Reminder>> ListRemindersPaginatedAsync(int pageIndex, int pageSize, CancellationToken cancellationToken);
     Task<List<Reminder>> ListRemindersByNodeIdPaginatedAsync(NodeId nodeId, int pageIndex, int pageSize, CancellationToken cancellationToken);
     Task<Reminder> GetReminderByIdAsync(ReminderId reminderId, CancellationToken cancellationToken);
-    Task<long> ReminderCountAsync(CancellationToken cancellationToken);
-    Task<long> ReminderCountByNodeIdAsync(NodeId nodeId, CancellationToken cancellationToken);
+    Task<long> CountAllRemindersAsync(CancellationToken cancellationToken);
+    Task<long> CountAllRemindersByNodeIdAsync(NodeId nodeId, CancellationToken cancellationToken);
 
     Task<IEnumerable<Reminder>> GetRemindersBelongingToNodeIdsAsync(IEnumerable<NodeId> nodeIds, CancellationToken cancellationToken);
 

--- a/Backend/src/Modules/Reminders/Reminders.Application/Data/RemindersService.cs
+++ b/Backend/src/Modules/Reminders/Reminders.Application/Data/RemindersService.cs
@@ -63,14 +63,14 @@ public class RemindersService(IServiceProvider serviceProvider, IRemindersReposi
         return reminderBaseDtos;
     }
 
-    public async Task<long> CountRemindersAsync(CancellationToken cancellationToken)
+    public async Task<long> CountAllRemindersAsync(CancellationToken cancellationToken)
     {
-        return await remindersRepository.ReminderCountAsync(cancellationToken);
+        return await remindersRepository.CountAllRemindersAsync(cancellationToken);
     }
 
-    public async Task<long> CountRemindersByNodeIdAsync(NodeId nodeId, CancellationToken cancellationToken)
+    public async Task<long> CountAllRemindersByNodeIdAsync(NodeId nodeId, CancellationToken cancellationToken)
     {
-        return await remindersRepository.ReminderCountByNodeIdAsync(nodeId, cancellationToken);
+        return await remindersRepository.CountAllRemindersByNodeIdAsync(nodeId, cancellationToken);
     }
 
     public async Task DeleteReminder(ReminderId reminderId, CancellationToken cancellationToken)

--- a/Backend/src/Modules/Reminders/Reminders.Application/Entities/Reminders/Queries/ListReminders/ListRemindersHandler.cs
+++ b/Backend/src/Modules/Reminders/Reminders.Application/Entities/Reminders/Queries/ListReminders/ListRemindersHandler.cs
@@ -11,15 +11,13 @@ public class ListRemindersHandler(IRemindersService remindersService) : IQueryHa
         var pageIndex = query.PaginationRequest.PageIndex;
         var pageSize = query.PaginationRequest.PageSize;
 
-        var totalCount = await remindersService.CountRemindersAsync(cancellationToken);
-
         var reminders = await remindersService.ListRemindersPaginated(pageIndex, pageSize, cancellationToken);
 
         return new ListRemindersResult(
             new PaginatedResult<ReminderDto>(
                 pageIndex,
                 pageSize,
-                totalCount,
+                reminders.Count,
                 reminders));
     }
 }

--- a/Backend/src/Modules/Reminders/Reminders.Infrastructure/Data/Repositories/RemindersRepository.cs
+++ b/Backend/src/Modules/Reminders/Reminders.Infrastructure/Data/Repositories/RemindersRepository.cs
@@ -44,14 +44,14 @@ public class RemindersRepository(ICurrentUser currentUser, IRemindersDbContext d
                throw new ReminderNotFoundException(reminderId.ToString());
     }
 
-    public async Task<long> ReminderCountAsync(CancellationToken cancellationToken)
+    public async Task<long> CountAllRemindersAsync(CancellationToken cancellationToken)
     {
         return await dbContext.Reminders
             .Where(r => r.OwnerId == currentUser.UserId!)
             .LongCountAsync(cancellationToken);
     }
 
-    public async Task<long> ReminderCountByNodeIdAsync(NodeId nodeId, CancellationToken cancellationToken)
+    public async Task<long> CountAllRemindersByNodeIdAsync(NodeId nodeId, CancellationToken cancellationToken)
     {
         return await dbContext.Reminders
             .Where(r => r.OwnerId == currentUser.UserId!)

--- a/Backend/src/Modules/Reminders/Reminders.Infrastructure/Data/Repositories/RemindersRepository.cs
+++ b/Backend/src/Modules/Reminders/Reminders.Infrastructure/Data/Repositories/RemindersRepository.cs
@@ -29,7 +29,7 @@ public class RemindersRepository(ICurrentUser currentUser, IRemindersDbContext d
     {
         return await dbContext.Reminders
             .AsNoTracking()
-            .Where(r => r.NodeId == nodeId && r.OwnerId == currentUser.UserId! && r.IsDeleted == false)
+            .Where(r => r.NodeId == nodeId && r.OwnerId == currentUser.UserId! && !r.IsDeleted)
             .OrderBy(r => r.CreatedAt)
             .Skip(pageIndex * pageSize)
             .Take(pageSize)

--- a/Backend/src/Modules/Timelines/Timelines.Application/Data/Abstractions/ITimelinesRepository.cs
+++ b/Backend/src/Modules/Timelines/Timelines.Application/Data/Abstractions/ITimelinesRepository.cs
@@ -6,7 +6,7 @@ namespace Timelines.Application.Data.Abstractions;
 public interface ITimelinesRepository
 {
     Task<List<Timeline>> ListTimelinesPaginatedAsync(int pageIndex, int pageSize, CancellationToken cancellationToken);
-    Task<long> TimelineCountAsync(CancellationToken cancellationToken);
+    Task<long> CountAllTimelinesAsync(CancellationToken cancellationToken);
 
     Task<Timeline> GetTimelineByIdAsync(TimelineId timelineId, CancellationToken cancellationToken);
     Task<Timeline> GetTrackedTimelineByIdAsync(TimelineId timelineId, CancellationToken cancellationToken);

--- a/Backend/src/Modules/Timelines/Timelines.Application/Data/TimelinesService.cs
+++ b/Backend/src/Modules/Timelines/Timelines.Application/Data/TimelinesService.cs
@@ -70,9 +70,9 @@ public class TimelinesService(IServiceProvider serviceProvider, ITimelinesReposi
             .ToList();
         return timelineDtos;
     }
-    public async Task<long> CountTimelinesAsync(CancellationToken cancellationToken)
+    public async Task<long> CountAllTimelinesAsync(CancellationToken cancellationToken)
     {
-        return await timelinesRepository.TimelineCountAsync(cancellationToken);
+        return await timelinesRepository.CountAllTimelinesAsync(cancellationToken);
     }
 
     public async Task EnsureTimelineBelongsToOwner(TimelineId timelineId, CancellationToken cancellationToken)

--- a/Backend/src/Modules/Timelines/Timelines.Application/Entities/Phases/Queries/ListPhases/ListPhasesHandler.cs
+++ b/Backend/src/Modules/Timelines/Timelines.Application/Entities/Phases/Queries/ListPhases/ListPhasesHandler.cs
@@ -11,15 +11,13 @@ internal class ListPhasesHandler(IPhasesService phasesService) : IQueryHandler<L
         var pageIndex = query.PaginationRequest.PageIndex;
         var pageSize = query.PaginationRequest.PageSize;
 
-        var totalCount = await phasesService.CountPhasesAsync(cancellationToken);
-
         var phases = await phasesService.ListPhasesPaginated(pageIndex, pageSize, cancellationToken);
 
         return new ListPhasesResult(
             new PaginatedResult<PhaseDto>(
                 pageIndex,
                 pageSize,
-                totalCount,
+                phases.Count,
                 phases));
     }
 }

--- a/Backend/src/Modules/Timelines/Timelines.Application/Entities/Timelines/Queries/ListNodesByTimelineId/ListNodesByTimelineIdHandler.cs
+++ b/Backend/src/Modules/Timelines/Timelines.Application/Entities/Timelines/Queries/ListNodesByTimelineId/ListNodesByTimelineIdHandler.cs
@@ -11,15 +11,13 @@ public class ListNodesByTimelineIdHandler(INodesService nodesService) : IQueryHa
         var pageIndex = query.PaginationRequest.PageIndex;
         var pageSize = query.PaginationRequest.PageSize;
 
-        var totalCount = await nodesService.CountNodesByTimelineIdAsync(query.Id, cancellationToken);
-
         var nodes = await nodesService.ListNodesByTimelineIdPaginated(query.Id, pageIndex, pageSize, cancellationToken);
 
         return new ListNodesByTimelineIdResult(
             new PaginatedResult<NodeBaseDto>(
                 pageIndex,
                 pageSize,
-                totalCount,
+                nodes.Count,
                 nodes));
     }
 }

--- a/Backend/src/Modules/Timelines/Timelines.Application/Entities/Timelines/Queries/ListTimelines/ListTimelinesHandler.cs
+++ b/Backend/src/Modules/Timelines/Timelines.Application/Entities/Timelines/Queries/ListTimelines/ListTimelinesHandler.cs
@@ -11,15 +11,13 @@ public class ListTimelinesHandler(ITimelinesService timelineService) : IQueryHan
         var pageIndex = query.PaginationRequest.PageIndex;
         var pageSize = query.PaginationRequest.PageSize;
 
-        var totalCount = await timelineService.CountTimelinesAsync(cancellationToken);
-
         var nodes = await timelineService.ListTimelinesPaginated(pageIndex, pageSize, cancellationToken);
 
         return new ListTimelinesResult(
             new PaginatedResult<TimelineDto>(
                 pageIndex,
                 pageSize,
-                totalCount,
+                nodes.Count,
                 nodes));
     }
 }

--- a/Backend/src/Modules/Timelines/Timelines.Application/Entities/Timelines/Queries/ListTimelines/ListTimelinesHandler.cs
+++ b/Backend/src/Modules/Timelines/Timelines.Application/Entities/Timelines/Queries/ListTimelines/ListTimelinesHandler.cs
@@ -11,13 +11,13 @@ public class ListTimelinesHandler(ITimelinesService timelineService) : IQueryHan
         var pageIndex = query.PaginationRequest.PageIndex;
         var pageSize = query.PaginationRequest.PageSize;
 
-        var nodes = await timelineService.ListTimelinesPaginated(pageIndex, pageSize, cancellationToken);
+        var timelines = await timelineService.ListTimelinesPaginated(pageIndex, pageSize, cancellationToken);
 
         return new ListTimelinesResult(
             new PaginatedResult<TimelineDto>(
                 pageIndex,
                 pageSize,
-                nodes.Count,
-                nodes));
+                timelines.Count,
+                timelines));
     }
 }

--- a/Backend/src/Modules/Timelines/Timelines.Infrastructure/Data/Repositories/TimelinesRepository.cs
+++ b/Backend/src/Modules/Timelines/Timelines.Infrastructure/Data/Repositories/TimelinesRepository.cs
@@ -21,7 +21,7 @@ public class TimelinesRepository(ICurrentUser currentUser, ITimelinesDbContext d
             .ToListAsync(cancellationToken: cancellationToken);
     }
 
-    public async Task<long> TimelineCountAsync(CancellationToken cancellationToken)
+    public async Task<long> CountAllTimelinesAsync(CancellationToken cancellationToken)
     {
         return await dbContext.Timelines
             .Where(t => t.OwnerId == currentUser.UserId! && !t.IsDeleted)


### PR DESCRIPTION
In this PR I have:
- Removed the `totalCount` variable from every entity listing handler and replaced with `entity`.Count 
- Some variable renames to match the logic